### PR TITLE
Change uboot git repo to new github location

### DIFF
--- a/recipes-bsp/u-boot/u-boot-socfpga.inc
+++ b/recipes-bsp/u-boot/u-boot-socfpga.inc
@@ -10,7 +10,7 @@ PACKAGES=""
 
 # the following variables can be passed from the env
 # using BB_ENV_WHITELIST to override the defaults
-UBOOT_REPO ?= "git://git.rocketboards.org/u-boot-socfpga.git"
+UBOOT_REPO ?= "git://github.com/altera-opensource/u-boot-socfpga.git"
 UBOOT_BRANCH ?= "socfpga_v${PV}"
 UBOOT_PROT ?= "http"
 UBOOT_TAG ?= "${AUTOREV}"

--- a/recipes-kernel/linux/linux-altera-dev.bb
+++ b/recipes-kernel/linux/linux-altera-dev.bb
@@ -1,0 +1,3 @@
+LINUX_VERSION = "4.2"
+
+include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera-ltsi-dev.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi-dev.bb
@@ -1,7 +1,5 @@
 LINUX_VERSION = "3.10"
-LINUX_VERSION_SUFFIX = "-ltsi-rt"
-
-SRCREV = "ef8b7fee9f81be67c97e461aa138a1b066f5e0a4"
+LINUX_VERSION_SUFFIX = "-ltsi"
 
 KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5.dtb"
 KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5.dtb"

--- a/recipes-kernel/linux/linux-altera-ltsi_3.10.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi_3.10.bb
@@ -1,6 +1,8 @@
 LINUX_VERSION = "3.10"
 LINUX_VERSION_SUFFIX = "-ltsi"
 
+SRCREV = "bcf9c6441ec6e785ec1c829b4650a582b5e7559e"
+
 KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5.dtb"
 KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5.dtb"
 

--- a/recipes-kernel/linux/linux-altera_4.0.bb
+++ b/recipes-kernel/linux/linux-altera_4.0.bb
@@ -1,3 +1,5 @@
 LINUX_VERSION = "4.0"
 
+SRCREV = "5d36469775e2b77a33e778d1b606edfc5ed13bd4"
+
 include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera_4.1.bb
+++ b/recipes-kernel/linux/linux-altera_4.1.bb
@@ -1,3 +1,5 @@
 LINUX_VERSION = "4.1"
 
+SRCREV = "186070d46805086fe9b46d95ac6d0e257203e5a4"
+
 include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera_4.2.bb
+++ b/recipes-kernel/linux/linux-altera_4.2.bb
@@ -1,3 +1,5 @@
 LINUX_VERSION = "4.2"
 
+SRCREV = "e7c206510d7606d38f71ad70bad377e390734958"
+
 include linux-altera.inc


### PR DESCRIPTION
Just noticed the cyclone5 / arria5 uboot recipe still pointed to rocketboards git repo