### PR TITLE
Update linux-altera-ltsi_3.10.bb

### DIFF
--- a/recipes-kernel/linux/linux-altera-ltsi_3.10.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi_3.10.bb
@@ -1,7 +1,7 @@
 LINUX_VERSION = "3.10"
 LINUX_VERSION_SUFFIX = "-ltsi"
 
-SRCREV = "bcf9c6441ec6e785ec1c829b4650a582b5e7559e"
+SRCREV = "22e8856f546423a4f45613c9fb0428ff9e395c7e"
 
 KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5.dtb"
 KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5.dtb"


### PR DESCRIPTION
I followed the instructions here
http://rocketboards.org/foswiki/view/Documentation/AngstromOnSoCFPGA_1
for Angstrom v2015.12 / Yocto 2.0 

I used the 3.10-ltsi kernel
=>
update patch which is searched as I got the following ERROR: Fetcher failure: Unable to find revision bcf9c6441ec6e785ec1c829b4650a582b5e7559e in branch socfpga-3.10-ltsi even from upstream