### PR TITLE
Update devicetree list for cyclone5 to include de0 board

### DIFF
--- a/recipes-kernel/linux/linux-altera.inc
+++ b/recipes-kernel/linux/linux-altera.inc
@@ -25,7 +25,7 @@ KBRANCH ?= "${LINUX_VERSION_PREFIX}${LINUX_VERSION}${LINUX_VERSION_SUFFIX}"
 SRC_URI = "${KERNEL_REPO};protocol=${KERNEL_PROT};branch=${KBRANCH}"
 
 # Default kernel devicetrees
-KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5_socdk.dtb socfpga_cyclone5_sockit.dtb socfpga_cyclone5_socrates.dtb"
+KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5_socdk.dtb socfpga_cyclone5_sockit.dtb socfpga_cyclone5_socrates.dtb socfpga_cyclone5_de0_sockit.dtb"
 KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5_socdk.dtb"
 KERNEL_DEVICETREE_arria10 ?= "socfpga_arria10_socdk_sdmmc.dtb socfpga_arria10_socdk_qspi.dtb socfpga_arria10_swvp.dtb"
 

--- a/recipes-kernel/linux/linux-altera_4.0.bb
+++ b/recipes-kernel/linux/linux-altera_4.0.bb
@@ -2,4 +2,7 @@ LINUX_VERSION = "4.0"
 
 SRCREV = "5d36469775e2b77a33e778d1b606edfc5ed13bd4"
 
+# There is no de0 devicetree in this kernel version
+KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
+
 include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera_4.1.bb
+++ b/recipes-kernel/linux/linux-altera_4.1.bb
@@ -1,5 +1,8 @@
 LINUX_VERSION = "4.1"
 
-SRCREV = "186070d46805086fe9b46d95ac6d0e257203e5a4"
+SRCREV = "6de99ee01c82b4b1d407f1393fe7d5413b5855cf"
+
+# There is no de0 devicetree in this kernel version
+KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
 
 include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera_4.2.bb
+++ b/recipes-kernel/linux/linux-altera_4.2.bb
@@ -2,4 +2,6 @@ LINUX_VERSION = "4.2"
 
 SRCREV = "be211eb308a6383da2042863ac070bc6e7d0add2"
 
+KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
+
 include linux-altera.inc


### PR DESCRIPTION
	-> Add de0 board device tree to default list
	-> disable de0 dts for 4.0/4.1/4.2 kernels