### PR TITLE
Remove kernels that are no longer supported or in development

### DIFF
--- a/recipes-kernel/linux/linux-altera-ltsi-rt_3.10.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi-rt_3.10.bb
@@ -1,9 +1,0 @@
-LINUX_VERSION = "3.10"
-LINUX_VERSION_SUFFIX = "-ltsi-rt"
-
-SRCREV = "5d6c0ba8572262c29ea3d97fe6d1d5b58650b6e5"
-
-KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5.dtb"
-KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5.dtb"
-
-include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera-ltsi_3.10.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi_3.10.bb
@@ -1,9 +1,0 @@
-LINUX_VERSION = "3.10"
-LINUX_VERSION_SUFFIX = "-ltsi"
-
-SRCREV = "28bac3edbcdc74f98b865986be5d340381896192"
-
-KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5.dtb"
-KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5.dtb"
-
-include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera_4.0.bb
+++ b/recipes-kernel/linux/linux-altera_4.0.bb
@@ -1,8 +1,0 @@
-LINUX_VERSION = "4.0"
-
-SRCREV = "5d36469775e2b77a33e778d1b606edfc5ed13bd4"
-
-# There is no de0 devicetree in this kernel version
-KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
-
-include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera_4.1.bb
+++ b/recipes-kernel/linux/linux-altera_4.1.bb
@@ -1,8 +1,0 @@
-LINUX_VERSION = "4.1"
-
-SRCREV = "6de99ee01c82b4b1d407f1393fe7d5413b5855cf"
-
-# There is no de0 devicetree in this kernel version
-KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
-
-include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera_4.2.bb
+++ b/recipes-kernel/linux/linux-altera_4.2.bb
@@ -1,7 +1,0 @@
-LINUX_VERSION = "4.2"
-
-SRCREV = "be211eb308a6383da2042863ac070bc6e7d0add2"
-
-KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
-
-include linux-altera.inc


### PR DESCRIPTION
	-> Remove 3.10 ltsi / 3.10 ltsi-rt recipes, 4.1 ltsi is available
	-> Remove 4.0 / 4.1 / 4.2 kernels

These kernels are no longer maintained, or developed and actually have build issues that will not be resolved.