### PR TITLE
Update linux-altera-configs to use alldefconfig instead of the defaul…

### DIFF
--- a/recipes-kernel/linux/linux-altera-configs.inc
+++ b/recipes-kernel/linux/linux-altera-configs.inc
@@ -1,3 +1,3 @@
 
 KBUILD_DEFCONFIG ?= "socfpga_defconfig"
-
+KCONFIG_MODE ?= "--alldefconfig"


### PR DESCRIPTION
…t of allnoconfig

i was seeing a difference in the kernel config between an non-angstrom build using socfgpa_defconfig and the angstrom build.  Turns out the angstrom config_me does allnoconfig by default.  change the linux-altera-config.inc to override the default to use --alldefconfig instead