### PR TITLE
Add back old LTSI kernels

### DIFF
--- a/recipes-kernel/linux/linux-altera-ltsi-rt_3.10.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi-rt_3.10.bb
@@ -1,0 +1,9 @@
+LINUX_VERSION = "3.10"
+LINUX_VERSION_SUFFIX = "-ltsi-rt"
+
+SRCREV = "5d6c0ba8572262c29ea3d97fe6d1d5b58650b6e5"
+
+KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5.dtb"
+KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5.dtb"
+
+include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera-ltsi_3.10.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi_3.10.bb
@@ -1,0 +1,9 @@
+LINUX_VERSION = "3.10"
+LINUX_VERSION_SUFFIX = "-ltsi"
+
+SRCREV = "28bac3edbcdc74f98b865986be5d340381896192"
+
+KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5.dtb"
+KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5.dtb"
+
+include linux-altera.inc


### PR DESCRIPTION
	-> These currently do not compile with the 5.2 toolchain
	-> You must use the 4.9 toolchain
	-> set ANGSTROM_GCC_VERSION_arm = "linaro-4.9%" in your local.conf
