### PR TITLE
add back Kernel version 4.2

### DIFF
--- a/recipes-kernel/linux/linux-altera_4.2.bb
+++ b/recipes-kernel/linux/linux-altera_4.2.bb
@@ -1,7 +1,7 @@
- -LINUX_VERSION = "4.2"
--
--SRCREV = "be211eb308a6383da2042863ac070bc6e7d0add2"
--
--KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
--
--include linux-altera.icn
+LINUX_VERSION = "4.2"
+
+SRCREV = "be211eb308a6383da2042863ac070bc6e7d0add2"
+
+KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
+
+include linux-altera.icn

--- a/recipes-kernel/linux/linux-altera_4.2.bb
+++ b/recipes-kernel/linux/linux-altera_4.2.bb
@@ -4,4 +4,4 @@ SRCREV = "be211eb308a6383da2042863ac070bc6e7d0add2"
 
 KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
 
-include linux-altera.icn
+include linux-altera.inc

--- a/recipes-kernel/linux/linux-altera_4.2.bb
+++ b/recipes-kernel/linux/linux-altera_4.2.bb
@@ -1,0 +1,7 @@
+ -LINUX_VERSION = "4.2"
+-
+-SRCREV = "be211eb308a6383da2042863ac070bc6e7d0add2"
+-
+-KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_sockit.dtb"
+-
+-include linux-altera.icn


### PR DESCRIPTION
@kraj @dwesterg 
could you add back kernel version 4.2
It's working for me with the settings described here
http://rocketboards.org/foswiki/view/Documentation/YoctoDoraBuildWithMetaAltera

and conf/local.conf
```
PREFERRED_PROVIDER_virtual/kernel = "linux-altera"
PREFERRED_VERSION_linux-altera = "4.2%"

GCCVERSION = "linaro-4.9"
SDKGCCVERSION = "linaro-4.9"
DEFAULTTUNE = "cortexa9hf-neon"
```

I like to use Kernel 4.2 as I found a SLD HUB Project ported to kernel 4.2
https://github.com/byates/altera_sld_hub_driver
https://github.com/byates/altera_mmlink
