### PR TITLE
Add support for mainline uboot for cyclone5 / arria5 devices

### DIFF
--- a/conf/machine/arria5.conf
+++ b/conf/machine/arria5.conf
@@ -4,8 +4,9 @@
 
 require conf/machine/include/socfpga.inc
 
-PREFERRED_VERSION_u-boot-socfpga ?= "2013.01.01"
-UBOOT_MACHINE = "socfpga_arria5"
+PREFERRED_VERSION_u-boot-socfpga ?= "2016.03"
+
+UBOOT_CONFIG ?= "arria5-socdk"
 
 KMACHINE = "arria5"
 

--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -4,8 +4,9 @@
 
 require conf/machine/include/socfpga.inc
 
-PREFERRED_VERSION_u-boot-socfpga ?= "2013.01.01"
-UBOOT_MACHINE = "socfpga_cyclone5"
+PREFERRED_VERSION_u-boot-socfpga ?= "2016.03"
+
+UBOOT_CONFIG ?= "cyclone5-socdk"
 
 KMACHINE = "cyclone5"
 

--- a/recipes-bsp/u-boot/u-boot-socfpga_2013.01.01.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_2013.01.01.bb
@@ -1,4 +1,0 @@
-# SoCEDS 15.1 u-Boot release
-UBOOT_TAG = "d141e218f3195e305c1521a0d67c81b7cb504b71"
-
-require u-boot-socfpga.inc

--- a/recipes-bsp/u-boot/u-boot-socfpga_2016.03.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_2016.03.bb
@@ -1,0 +1,28 @@
+require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+
+# This revision is the v2016.03 release
+SRCREV = "df61a74e6845ec9bdcdd48d2aff5e9c2c6debeaa"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+
+PV = "v2016.03"
+PV_append = "+git${SRCPV}"
+
+DEPENDS += "dtc-native"
+
+UBOOT_CONFIG ??= "cyclone5-socdk arria5-socdk de0-nano-soc sockit socrates"
+UBOOT_CONFIG[cyclone5-socdk] = "socfpga_cyclone5_defconfig"
+UBOOT_CONFIG[arria5-socdk] = "socfpga_arria5_defconfig"
+UBOOT_CONFIG[de0-nano-soc] = "socfpga_de0_nano_soc_defconfig"
+UBOOT_CONFIG[mcvevk] = "socfpga_mcvevk_defconfig"
+UBOOT_CONFIG[sockit] = "socfpga_sockit_defconfig"
+UBOOT_CONFIG[socrates] = "socfpga_socrates_defconfig"
+UBOOT_CONFIG[sr1500] = "socfpga_sr1500_defconfig"
+
+UBOOT_SUFFIX = "img"
+
+SPL_BINARY_cyclone5 = "u-boot-with-spl.sfp"
+SPL_BINARY_arria5 = "u-boot-with-spl.sfp"
+
+


### PR DESCRIPTION
        1) Remove 2013.01.01 u-boot which is only used
	   for cyclone5/arria5. cyclone5/arria5 are fully
	   supported in mainline uboot
        2) Add recipe for mainline uboot supporting socfpga
           cyclone5 / arria5 based kits.