### PR TITLE
SDcard fixes

### DIFF
--- a/conf/machine/arria5.conf
+++ b/conf/machine/arria5.conf
@@ -8,7 +8,7 @@ PREFERRED_VERSION_u-boot-socfpga ?= "2016.03%"
 
 UBOOT_CONFIG ??= "arria5-socdk"
 
-UBOOT_CONFIG[arria5-socdk] = "socfpga_arria5_defconfig,sdcard"
+UBOOT_CONFIG[arria5-socdk] = "socfpga_arria5_defconfig"
 
 KMACHINE = "arria5"
 
@@ -16,4 +16,4 @@ KMACHINE = "arria5"
 KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5_socdk.dtb"
 
 # Add support for SDCARD creation
-IMAGE_CLASSES += "image_types_socfpga
+IMAGE_CLASSES += "image_types_socfpga"

--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -8,8 +8,8 @@ PREFERRED_VERSION_u-boot-socfpga ?= "2016.03%"
 
 UBOOT_CONFIG ??= "cyclone5-socdk"
 
-UBOOT_CONFIG[cyclone5-socdk] = "socfpga_cyclone5_defconfig,sdcard"
-UBOOT_CONFIG[de0-nano-soc] = "socfpga_de0_nano_soc_defconfig,sdcard"
+UBOOT_CONFIG[cyclone5-socdk] = "socfpga_cyclone5_defconfig"
+UBOOT_CONFIG[de0-nano-soc] = "socfpga_de0_nano_soc_defconfig"
 UBOOT_CONFIG[mcvevk] = "socfpga_mcvevk_defconfig"
 UBOOT_CONFIG[sockit] = "socfpga_sockit_defconfig"
 UBOOT_CONFIG[socrates] = "socfpga_socrates_defconfig"


### PR DESCRIPTION
        1) Disable sdcard generation using UBOOT_CONFIG parameter
        2) Fix type in sdcard class

SDCard generation still isnt working quite right.  If
IMAGE_FSTYPES += " sdcard" is added, the sdcard image
is created but the uboot-config should automatically
add sdcard creation when the UBOOT_CONFIG selected
looks like "socfpga_cyclone5_socdk,sdcard".

TBD:
        1) Add uboot env customization based on
           selected uboot config
        2) Fix sdcard generation issue