### PR TITLE
Fix error in FILESEXTRAPATH assignment in ltsi kernel recipes

### DIFF
--- a/recipes-kernel/linux/linux-altera-ltsi-dev_4.1.22.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi-dev_4.1.22.bb
@@ -3,7 +3,7 @@ LINUX_VERSION_SUFFIX = "-ltsi"
 
 include linux-altera.inc
 
-FILESEXTRAPATHS := "${FILE_DIRNAME}/linux-altera-ltsi:"
+FILESEXTRAPATHS .= "${FILE_DIRNAME}/linux-altera-ltsi:"
 
 SRC_URI += "\
            file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \

--- a/recipes-kernel/linux/linux-altera-ltsi-dev_4.1.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi-dev_4.1.bb
@@ -3,7 +3,7 @@ LINUX_VERSION_SUFFIX = "-ltsi"
 
 include linux-altera.inc
 
-FILESEXTRAPATHS := "${FILE_DIRNAME}/linux-altera-ltsi:"
+FILESEXTRAPATHS .= "${FILE_DIRNAME}/linux-altera-ltsi:"
 
 SRC_URI += "\
            file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \

--- a/recipes-kernel/linux/linux-altera-ltsi-rt-dev_4.1.22.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi-rt-dev_4.1.22.bb
@@ -3,7 +3,7 @@ LINUX_VERSION_SUFFIX = "-ltsi-rt"
 
 include linux-altera.inc
 
-FILESEXTRAPATHS := "${FILE_DIRNAME}/linux-altera-ltsi:"
+FILESEXTRAPATHS .= "${FILE_DIRNAME}/linux-altera-ltsi:"
 
 SRC_URI += "\
            file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \

--- a/recipes-kernel/linux/linux-altera-ltsi-rt_4.1.22.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi-rt_4.1.22.bb
@@ -5,7 +5,7 @@ SRCREV = "0e938a8fafccb73ad70781ed62abda2b554eafb4"
 
 include linux-altera.inc
 
-FILESEXTRAPATHS := "${FILE_DIRNAME}/linux-altera-ltsi:"
+FILESEXTRAPATHS .= "${FILE_DIRNAME}/linux-altera-ltsi:"
 
 SRC_URI += "\
            file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \

--- a/recipes-kernel/linux/linux-altera-ltsi-rt_4.1.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi-rt_4.1.bb
@@ -5,7 +5,7 @@ SRCREV = "8b4890ed684b422689394156f8a555d522aaf5db"
 
 include linux-altera.inc
 
-FILESEXTRAPATHS := "${FILE_DIRNAME}/linux-altera-ltsi:"
+FILESEXTRAPATHS .= "${FILE_DIRNAME}/linux-altera-ltsi:"
 
 SRC_URI += "\
            file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \

--- a/recipes-kernel/linux/linux-altera-ltsi_4.1.22.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi_4.1.22.bb
@@ -5,7 +5,7 @@ SRCREV = "48a39aeb13e390b8c9b7076d49d73aa26b3de41c"
 
 include linux-altera.inc
 
-FILESEXTRAPATHS := "${FILE_DIRNAME}/linux-altera-ltsi:"
+FILESEXTRAPATHS .= "${FILE_DIRNAME}/linux-altera-ltsi:"
 
 SRC_URI += "\
            file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \

--- a/recipes-kernel/linux/linux-altera-ltsi_4.1.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi_4.1.bb
@@ -5,7 +5,7 @@ SRCREV = "43492a7a9649e30826e4c79a9308ab2850259c26"
 
 include linux-altera.inc
 
-FILESEXTRAPATHS := "${FILE_DIRNAME}/linux-altera-ltsi:"
+FILESEXTRAPATHS .= "${FILE_DIRNAME}/linux-altera-ltsi:"
 
 SRC_URI += "\
            file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \


### PR DESCRIPTION
Missed the ".=" rather than the ":="

--dalon