### PR TITLE
Update 4.1.22 ltsi and 4.6 SRCREV to latest hash tag

### DIFF
--- a/recipes-kernel/linux/linux-altera-ltsi_4.1.22.bb
+++ b/recipes-kernel/linux/linux-altera-ltsi_4.1.22.bb
@@ -1,7 +1,7 @@
 LINUX_VERSION = "4.1.22"
 LINUX_VERSION_SUFFIX = "-ltsi"
 
-SRCREV = "48a39aeb13e390b8c9b7076d49d73aa26b3de41c"
+SRCREV = "9862a6691b3f0d5496f39f7b21f6c876dee1549c"
 
 include linux-altera.inc
 

--- a/recipes-kernel/linux/linux-altera_4.6.bb
+++ b/recipes-kernel/linux/linux-altera_4.6.bb
@@ -1,5 +1,5 @@
 LINUX_VERSION = "4.6"
 
-SRCREV = "9d08abae8b2cf7dbc69c7e17b84109906ed9c721"
+SRCREV = "49f1664be97b67645ca7625bec2b7a414333987e"
 
 include linux-altera.inc


### PR DESCRIPTION
this fixes a problem with devicetree overlays and bridge resets