### PR TITLE
linux-altera: 4.4: fix wrong SRCREV

### DIFF
--- a/recipes-kernel/linux/linux-altera_4.4.bb
+++ b/recipes-kernel/linux/linux-altera_4.4.bb
@@ -1,5 +1,5 @@
 LINUX_VERSION = "4.4"
 
-SRCREV = "0e938a8fafccb73ad70781ed62abda2b554eafb4"
+SRCREV = "84eb65f84ea7a15cd73766fb16e6a868dc7a734b"
 
 include linux-altera.inc


### PR DESCRIPTION
commit: 0e938a8fafccb73ad70781ed62abda2b554eafb4 is not included in socfpga-4.4
branch. Therefore, build of linux-altera_4.4 recipe will fail.
This sets 84eb65f84ea7a15cd73766fb16e6a868dc7a734b is current HEAD of
socfpga-4.4 to SRCREV.

Signed-off-by: Nobuhiro Iwamatsu <nobuhiro.iwamatsu.kw@hitachi.com>