### PR TITLE
linux-altera: fix QA error on kernel PV mismatch

### DIFF
--- a/recipes-kernel/linux/linux-altera.inc
+++ b/recipes-kernel/linux/linux-altera.inc
@@ -16,7 +16,7 @@ LINUX_VERSION ?= "4.0"
 
 SRCREV ?= "${AUTOREV}"
 SRCREV_machine ?= "${AUTOREV}"
-PV = "${LINUX_VERSION}"
+PV = "${LINUX_VERSION}${LINUX_VERSION_SUFFIX}"
 PV_append = "+git${SRCPV}"
 
 


### PR DESCRIPTION
Commit 0eacf03de18b7eeb3460a4d102dd5932cd73cd06 in poky master introduced
a new QA test that linux-altera recipes are currently failing with:

ERROR: linux-altera-ltsi-4.1.22+gitAUTOINC+76bdba2700-r0
do_kernel_version_sanity_check: Package Version (4.1.22+gitAUTOINC+76bdba2700)
does not match of kernel being built (4.1.22-ltsi). Please update the PV
variable to match the kernel source.

Append ${LINUX_VERSION_SUFFIX} to PV to match version information in kernel's
Makefile.

This is a naive solution that ends up with names like linux-altera-ltsi-4.1.22-ltsi+gitAUTOINC+76bdba2700-r0. Feel free to drop if you know a cleaner fix. 