### PR TITLE
u-boot-socfpga: Remove unnecessary 10m50 additions in v2016.05

### DIFF
--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.05.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.05.bb
@@ -7,23 +7,3 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 SRCREV = "aeaec0e682f45b9e0c62c522fafea353931f73ed"
 
 DEPENDS += "dtc-native"
-
-do_install_append_10m50 () {
-    if [ "x${UBOOT_CONFIG}" != "x" ]
-    then
-        for config in ${UBOOT_MACHINE}; do
-            install -d ${D}/boot
-            install ${B}/${config}/${UBOOT_DTB_BINARY} ${D}/boot/${UBOOT_DTB_BINARY}
-            install ${B}/${config}/${UBOOT_NODTB_BINARY} ${D}/boot/${UBOOT_NODTB_BINARY}
-        done
-    else
-        install -d ${D}/boot
-        install ${B}/${config}/${UBOOT_DTB_BINARY} ${D}/boot/${UBOOT_DTB_BINARY}
-        install ${B}/${config}/${UBOOT_NODTB_BINARY} ${D}/boot/${UBOOT_NODTB_BINARY}
-    fi
-}
-
-do_deploy_append_10m50 () {
-    install ${D}/boot/${UBOOT_DTB_BINARY} ${DEPLOYDIR}/${UBOOT_DTB_BINARY}
-    install ${D}/boot/${UBOOT_NODTB_BINARY} ${DEPLOYDIR}/${UBOOT_NODTB_BINARY}
-}

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
@@ -7,4 +7,3 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 SRCREV = "29e0cfb4f77f7aa369136302cee14a91e22dca71"
 
 DEPENDS += "dtc-native"
-


### PR DESCRIPTION
No longer removing the common include for u-boot-socfpga, but cleaning up v2016.05 to remove extraneous 10m50 additions.  The files being added for the 10m50 are not needed.

Signed-off-by: Dalon Westergreen <dalon.westergreen@intel.com>