### PR TITLE
Add support to fix arria10 u-boot-socfpga v2014.10 build with gcc6

### DIFF
--- a/recipes-bsp/u-boot/files/v2014.10/fix-build-error-under-gcc6.patch
+++ b/recipes-bsp/u-boot/files/v2014.10/fix-build-error-under-gcc6.patch
@@ -1,0 +1,91 @@
+From 07373b2e477ae61f9f6a0e2eff41be3276d92923 Mon Sep 17 00:00:00 2001
+From: yocto <yocto@yocto.org>
+Date: Thu, 2 Jun 2016 03:21:51 -0500
+Subject: [PATCH] fix build error under gcc6
+
+Fix the following error:
+| ../include/linux/compiler-gcc.h:114:30: fatal error: linux/compiler-gcc6.h: No such file or directory
+|  #include gcc_header(__GNUC__)
+
+Signed-off-by: Zhenhua Luo <zhenhua.luo@nxp.com>
+
+Upstream-Status: Pending
+---
+ include/linux/compiler-gcc6.h | 65 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 65 insertions(+)
+ create mode 100644 include/linux/compiler-gcc6.h
+
+diff --git a/include/linux/compiler-gcc6.h b/include/linux/compiler-gcc6.h
+new file mode 100644
+index 0000000..c8c5659
+--- /dev/null
++++ b/include/linux/compiler-gcc6.h
+@@ -0,0 +1,65 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc5.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used				__attribute__((__used__))
++#define __must_check			__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++   to them will be unlikely.  This means a lot of manual unlikely()s
++   are unnecessary now for any paths leading to the usual suspects
++   like BUG(), printk(), panic() etc. [but let's keep them for now for
++   older compilers]
++
++   Early snapshots of gcc 4.3 don't support this and we can't detect this
++   in the preprocessor, but we can live with this because they're unreleased.
++   Maketime probing would be overkill here.
++
++   gcc also has a __attribute__((__hot__)) to move hot functions into
++   a special section, but I don't see any sense in this right now in
++   the kernel context */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
+-- 
+2.5.0
+

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2014.10.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2014.10.bb
@@ -7,7 +7,10 @@ UBOOT_BRANCH ?= "socfpga_${PV}_arria10_bringup"
 UBOOT_REPO ?= "git://github.com/altera-opensource/u-boot-socfpga.git"
 UBOOT_PROT ?= "https"
 
-SRC_URI = "${UBOOT_REPO};protocol=${UBOOT_PROT};branch=${UBOOT_BRANCH}"
+SRC_URI = "\
+	${UBOOT_REPO};protocol=${UBOOT_PROT};branch=${UBOOT_BRANCH} \
+	file://v2014.10/fix-build-error-under-gcc6.patch \
+	"
 
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=c7383a594871c03da76b3707929d2919"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.05.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.05.bb
@@ -7,23 +7,3 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 SRCREV = "aeaec0e682f45b9e0c62c522fafea353931f73ed"
 
 DEPENDS += "dtc-native"
-
-do_install_append_10m50 () {
-    if [ "x${UBOOT_CONFIG}" != "x" ]
-    then
-        for config in ${UBOOT_MACHINE}; do
-            install -d ${D}/boot
-            install ${B}/${config}/${UBOOT_DTB_BINARY} ${D}/boot/${UBOOT_DTB_BINARY}
-            install ${B}/${config}/${UBOOT_NODTB_BINARY} ${D}/boot/${UBOOT_NODTB_BINARY}
-        done
-    else
-        install -d ${D}/boot
-        install ${B}/${config}/${UBOOT_DTB_BINARY} ${D}/boot/${UBOOT_DTB_BINARY}
-        install ${B}/${config}/${UBOOT_NODTB_BINARY} ${D}/boot/${UBOOT_NODTB_BINARY}
-    fi
-}
-
-do_deploy_append_10m50 () {
-    install ${D}/boot/${UBOOT_DTB_BINARY} ${DEPLOYDIR}/${UBOOT_DTB_BINARY}
-    install ${D}/boot/${UBOOT_NODTB_BINARY} ${DEPLOYDIR}/${UBOOT_NODTB_BINARY}
-}

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
@@ -7,4 +7,3 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 SRCREV = "29e0cfb4f77f7aa369136302cee14a91e22dca71"
 
 DEPENDS += "dtc-native"
-


### PR DESCRIPTION
Patch references by Khem worked like a charm, also clean up some 10m50 stuff that isnt needed.