### PR TITLE
add support to generate uboot environment images

### DIFF
--- a/classes/sdcard_image-socfpga.bbclass
+++ b/classes/sdcard_image-socfpga.bbclass
@@ -26,6 +26,7 @@ FAT_SPACE ?= "102400"
 
 # uBoot ENV offset
 SDIMG_UBOOT_ENV_OFFSET ?= "512"
+ENV_BASE_NAME ??= "${UBOOT_CONFIG}" 
 
 # Boot partition begin at sector 1024
 # This is required as for c5/a5 mainline uboot hard codes the location
@@ -173,7 +174,7 @@ IMAGE_CMD_socfpga-sdimg () {
 	fi
 	
 	if [ -e "${DEPLOY_DIR_IMAGE}/u-boot-env-${ENV_BASE_NAME}.bin" ]; then 
-		dd if=${DEPLOY_DIR_IMAGE}/u-boot-env-${ENV_BASE_NAME}.bin of=${SDIMG} bs=1 seek=${SDIMG_UBOOT_ENV_OFFSET}
+		dd if=${DEPLOY_DIR_IMAGE}/u-boot-env-${ENV_BASE_NAME}.bin of=${SDIMG} conv=notrunc bs=1 seek=${SDIMG_UBOOT_ENV_OFFSET} && sync && sync
 	fi
 	
 }

--- a/recipes-bsp/u-boot/files/v2016.11/cyclone5-socdk.env
+++ b/recipes-bsp/u-boot/files/v2016.11/cyclone5-socdk.env
@@ -1,0 +1,11 @@
+baudrate=115200
+bootargs=console=ttyS0,115200
+bootcmd=run mmcload; run mmcboot
+fdtimage=socfpga_cyclone5_socdk.dtb
+bootimage=zImage
+fdt_addr=100
+loadaddr=0x01000000
+mmcboot=setenv bootargs console=ttyS0,115200 root=${mmcroot} rw rootwait;bootz ${loadaddr} - ${fdt_addr}
+mmcload=mmc rescan;load mmc 0:2 ${loadaddr} ${bootimage};load mmc 0:2 ${fdt_addr} ${fdtimage}
+mmcroot=/dev/mmcblk0p3
+ramboot=setenv bootargs console=ttyS0,115200;bootm ${loadaddr} - ${fdt_addr}

--- a/recipes-bsp/u-boot/u-boot-socfpga-env.inc
+++ b/recipes-bsp/u-boot/u-boot-socfpga-env.inc
@@ -10,13 +10,14 @@ ENV_BASE_NAME ??= "${UBOOT_CONFIG}"
 ENV_BASE_FILE = "${WORKDIR}/${ENV_BASE_NAME}.env"
 
 do_environment_mkimage() {
-	if  [ -e ${WORKDIR}/${PV}/${ENV_BASE_NAME}.env ]; then
-		mkenvimage -s ${ENV_SIZE} -o ${WORKDIR}/${ENV_BASE_NAME}.bin ${WORKDIR}/${PV}/${ENV_BASE_NAME}.env
+	if  [ -e "${WORKDIR}/${ENV_BASE_NAME}.env" ]; then
+		mkenvimage -s ${ENV_SIZE} -o ${WORKDIR}/${ENV_BASE_NAME}.bin ${WORKDIR}/${ENV_BASE_NAME}.env
 	fi
 }
 
 do_deploy_append() {
-    if [ -e ${WORKDIR}/${ENV_BASE_NAME}.bin]; then
+
+    if [ -e "${WORKDIR}/${ENV_BASE_NAME}.bin" ]; then
 	install -d ${DEPLOYDIR}
     	install -m 644 ${WORKDIR}/${ENV_BASE_NAME}.bin ${DEPLOYDIR}/u-boot-env-${ENV_BASE_NAME}.bin
     fi

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
@@ -13,6 +13,7 @@ PR = "r1"
 
 SRC_URI_append = "\
 	file://de0-nano-soc.env \
+	file://cyclone5-socdk.env \
 	"
 
 DEPENDS += "dtc-native"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
@@ -2,14 +2,17 @@ require u-boot-socfpga-common.inc
 require u-boot-socfpga-env.inc
 require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
+FILESEXTRAPATHS =. "files/v2016.11:"
+
 # This revision corresponds to the tag "v2016.11"
 # We use the revision in order to avoid having to fetch it from the
 # repo during parse 
 SRCREV = "29e0cfb4f77f7aa369136302cee14a91e22dca71"
 
-SRC_URI_append = "\
-	file://v2016.11/de0-nano-soc.env \
-	"
 PR = "r1"
+
+SRC_URI_append = "\
+	file://de0-nano-soc.env \
+	"
 
 DEPENDS += "dtc-native"


### PR DESCRIPTION
create uboot environment images to populate the sdcard
images.  This allows non-default uboot environments to be
used without the need for changing / patching uboot

Initially add de0-nano-soc environment