### PR TITLE
Cleanup to get ready to support extlinux.conf boot

### DIFF
--- a/recipes-bsp/u-boot/u-boot-mkenvimage_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-mkenvimage_v2016.11.bb
@@ -1,6 +1,16 @@
 SUMMARY = "U-Boot bootloader environment image creation tool"                               
 
-require u-boot-socfpga-common.inc
+HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"                             
+SECTION = "bootloaders"                                                         
+                                                                                
+LICENSE = "GPLv2+"                                                              
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+                                                                                
+PV_append = "+git${SRCPV}"                                                      
+                                                                                
+SRC_URI = "git://git.denx.de/u-boot.git;branch=master"                          
+                                                                                
+S = "${WORKDIR}/git" 
 
 # This revision corresponds to the tag "v2016.11"                               
 # We use the revision in order to avoid having to fetch it from the             

--- a/recipes-bsp/u-boot/u-boot-socfpga-common.inc
+++ b/recipes-bsp/u-boot/u-boot-socfpga-common.inc
@@ -9,3 +9,8 @@ PV_append = "+git${SRCPV}"
 SRC_URI = "git://git.denx.de/u-boot.git;branch=master"
 
 S = "${WORKDIR}/git"
+
+PROVIDES += "u-boot"                                                            
+PKG_${PN} = "u-boot"                                                            
+PKG_${PN}-dev = "u-boot-dev"                                                    
+PKG_${PN}-dbg = "u-boot-dbg"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2017.01.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2017.01.bb
@@ -1,0 +1,15 @@
+require u-boot-socfpga-common.inc
+require u-boot-socfpga-env.inc
+require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+
+FILESEXTRAPATHS =. "${THISDIR}/files/v2017.01:"
+
+# This revision corresponds to the tag "v2017.01"
+# We use the revision in order to avoid having to fetch it from the
+# repo during parse 
+SRCREV = "a705ebc81b7f91bbd0ef7c634284208342901149"
+
+PR = "r1"
+
+DEPENDS += "dtc-native"
+DEPENDS += "u-boot-mkimage-native"


### PR DESCRIPTION
when adding extlinux.conf generation to angstrom there is
a requirement for something that provides uboot.  This patch
adds a PROVIDES so that the package accurately reports that
it provides uboot

Signed-off-by: Dalon Westergreen <dalon.westergreen@intel.com>