### PR TITLE
Cleanup for extlinux.conf support and add initial u-boot 2017.01

### DIFF
--- a/conf/machine/arria5.conf
+++ b/conf/machine/arria5.conf
@@ -19,4 +19,3 @@ KERNEL_DEVICETREE_arria5 ?= " \
 
 # Add support for SDCARD creation
 IMAGE_CLASSES += "sdcard_image-socfpga"
-SOCFPGA_SDIMG_PARTITION_COMMAND ?= "generate_sdcard_partitions_v2016_11_and_newer"

--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -27,5 +27,4 @@ KERNEL_DEVICETREE ?= "\
 
 # Add support for SDCARD creation
 IMAGE_CLASSES += "sdcard_image-socfpga"
-SOCFPGA_SDIMG_PARTITION_COMMAND ?= "generate_sdcard_partitions_v2016_11_and_newer"
 

--- a/recipes-bsp/u-boot/files/v2016.11/cyclone5-socdk.env
+++ b/recipes-bsp/u-boot/files/v2016.11/cyclone5-socdk.env
@@ -6,6 +6,6 @@ bootimage=zImage
 fdt_addr=100
 loadaddr=0x01000000
 mmcboot=setenv bootargs console=ttyS0,115200 root=${mmcroot} rw rootwait;bootz ${loadaddr} - ${fdt_addr}
-mmcload=mmc rescan;load mmc 0:2 ${loadaddr} ${bootimage};load mmc 0:2 ${fdt_addr} ${fdtimage}
-mmcroot=/dev/mmcblk0p3
+mmcload=mmc rescan;load mmc 0:1 ${loadaddr} ${bootimage};load mmc 0:1 ${fdt_addr} ${fdtimage}
+mmcroot=/dev/mmcblk0p2
 ramboot=setenv bootargs console=ttyS0,115200;bootm ${loadaddr} - ${fdt_addr}

--- a/recipes-bsp/u-boot/files/v2016.11/de0-nano-soc.env
+++ b/recipes-bsp/u-boot/files/v2016.11/de0-nano-soc.env
@@ -6,6 +6,6 @@ bootimage=zImage
 fdt_addr=100
 loadaddr=0x01000000
 mmcboot=setenv bootargs console=ttyS0,115200 root=${mmcroot} rw rootwait;bootz ${loadaddr} - ${fdt_addr}
-mmcload=mmc rescan;load mmc 0:2 ${loadaddr} ${bootimage};load mmc 0:2 ${fdt_addr} ${fdtimage}
-mmcroot=/dev/mmcblk0p3
+mmcload=mmc rescan;load mmc 0:1 ${loadaddr} ${bootimage};load mmc 0:1 ${fdt_addr} ${fdtimage}
+mmcroot=/dev/mmcblk0p2
 ramboot=setenv bootargs console=ttyS0,115200;bootm ${loadaddr} - ${fdt_addr}

--- a/recipes-bsp/u-boot/u-boot-mkenvimage_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-mkenvimage_v2016.11.bb
@@ -1,6 +1,16 @@
 SUMMARY = "U-Boot bootloader environment image creation tool"                               
 
-require u-boot-socfpga-common.inc
+HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"                             
+SECTION = "bootloaders"                                                         
+                                                                                
+LICENSE = "GPLv2+"                                                              
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+                                                                                
+PV_append = "+git${SRCPV}"                                                      
+                                                                                
+SRC_URI = "git://git.denx.de/u-boot.git;branch=master"                          
+                                                                                
+S = "${WORKDIR}/git" 
 
 # This revision corresponds to the tag "v2016.11"                               
 # We use the revision in order to avoid having to fetch it from the             

--- a/recipes-bsp/u-boot/u-boot-socfpga-common.inc
+++ b/recipes-bsp/u-boot/u-boot-socfpga-common.inc
@@ -9,3 +9,5 @@ PV_append = "+git${SRCPV}"
 SRC_URI = "git://git.denx.de/u-boot.git;branch=master"
 
 S = "${WORKDIR}/git"
+
+RPROVIDES += "u-boot" 

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2017.01.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2017.01.bb
@@ -1,0 +1,13 @@
+require u-boot-socfpga-common.inc
+require u-boot-socfpga-env.inc
+require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+
+FILESEXTRAPATHS =. "${THISDIR}/files/v2017.01:"
+
+# This revision corresponds to the tag "v2017.01"
+# We use the revision in order to avoid having to fetch it from the
+# repo during parse 
+SRCREV = "a705ebc81b7f91bbd0ef7c634284208342901149"
+
+DEPENDS += "dtc-native"
+DEPENDS += "u-boot-mkimage-native"


### PR DESCRIPTION
uboot it moving to distro boot for socfgpa.  Adding the exlinux.conf bbclass currently fails with the socfpga uboot recipes.  

Adding initial 2017.01 uboot support