### PR TITLE
Add support for extra files in sdcard image

### DIFF
--- a/classes/sdcard_image-socfpga.bbclass
+++ b/classes/sdcard_image-socfpga.bbclass
@@ -141,6 +141,15 @@ IMAGE_CMD_socfpga-sdimg () {
 		
 	fi
 
+	# copy any files listed as extra files
+	if test -n "${SOCFPGA_SDIMG_EXTRA_FILES}"; then 
+		for EXTRA_FILE in ${SOCFPGA_SDIMG_EXTRA_FILES}; do
+			if [ -e "${DEPLOY_DIR_IMAGE}/${EXTRA_FILE}" ]; then
+				mcopy -i ${WORKDIR}/fat.img -s ${DEPLOY_DIR_IMAGE}/${EXTRA_FILE} ::/${EXTRA_FILE}
+			fi
+		done
+	fi
+
 	# Add stamp file
 	echo "${IMAGE_NAME}-${IMAGEDATESTAMP}" > ${WORKDIR}/image-version-info
 	mcopy -i ${WORKDIR}/fat.img -v ${WORKDIR}//image-version-info ::


### PR DESCRIPTION
I found a need to have additional files copied to the fat partition on the sdcard. Specifically it may be necessary to place an fpga bitstream on the sdcard to allow uboot to use it during boot to configure the fpga.  This adds support for arbitrarily copying files from the deploy directory to the fat partition on the sdcard by adding SOCFPGA_SDIMG_EXTRA_FILES to local.conf or the machine configuration.

SOCFPGA_SDIMG_EXTRA_FILES lists any files to be added from
the DEPLOYDIR to the FAT partition of the sdcard image

Signed-off-by: Dalon Westergreen <dalon.westergreen@intel.com>