### PR TITLE
Fix build with YP pyro

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Fix-native-build-by-using-env-variables.patch
+++ b/recipes-bsp/u-boot/files/0001-Fix-native-build-by-using-env-variables.patch
@@ -1,0 +1,31 @@
+From 5aa1e2d99a26f1cab1774fa1e94b53de42897d1c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan-Simon=20M=C3=B6ller?= <jsmoeller@linuxfoundation.org>
+Date: Thu, 10 Aug 2017 19:36:21 +0200
+Subject: [PATCH] Fix native build by using env variables
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jan-Simon Möller <jsmoeller@linuxfoundation.org>
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 8ca1db5..fef1059 100644
+--- a/Makefile
++++ b/Makefile
+@@ -254,8 +254,8 @@ CONFIG_SHELL := $(shell if [ -x "$$BASH" ]; then echo $$BASH; \
+ 	  else if [ -x /bin/bash ]; then echo /bin/bash; \
+ 	  else echo sh; fi ; fi)
+ 
+-HOSTCC       = cc
+-HOSTCXX      = c++
++HOSTCC       = $(CC)
++HOSTCXX      = $(CXX)
+ HOSTCFLAGS   = -Wall -Wstrict-prototypes -O2 -fomit-frame-pointer \
+ 		$(if $(CONFIG_TOOLS_DEBUG),-g)
+ HOSTCXXFLAGS = -O2
+-- 
+2.1.4
+

--- a/recipes-bsp/u-boot/u-boot-mkenvimage_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-mkenvimage_v2016.11.bb
@@ -8,7 +8,8 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
                                                                                 
 PV_append = "+git${SRCPV}"                                                      
                                                                                 
-SRC_URI = "git://git.denx.de/u-boot.git;branch=master"                          
+SRC_URI = "git://git.denx.de/u-boot.git;branch=master"
+SRC_URI += "file://0001-Fix-native-build-by-using-env-variables.patch"
                                                                                 
 S = "${WORKDIR}/git" 
 

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
@@ -16,5 +16,5 @@ SRC_URI_append = "\
 	file://cyclone5-socdk.env \
 	"
 
-DEPENDS += "dtc-native"
+DEPENDS += "dtc-native bc-native"
 DEPENDS += "u-boot-mkimage-native"


### PR DESCRIPTION
Mainly fix the u-boot build by:
- changing u-boot-mkenvimage to use $(CC) instead of cc
- adding bc-native to u-boot-socfpga due to RS-sysroot in YP

Signed-off-by: Jan-Simon Möller <jsmoeller@linuxfoundation.org>