### PR TITLE
Fix wic mount of sdcard fat partition

### DIFF
--- a/wic/sdimage-cyclone5-arria5.wks
+++ b/wic/sdimage-cyclone5-arria5.wks
@@ -3,6 +3,6 @@
 # Boot files are located in the first vfat partition and u-Boot is located in
 # the third partition.
 
-part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 16
+part --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 16
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4
 part /a2 --source rawcopy --sourceparams="file=u-boot-with-spl.sfp" --ondisk mmcblk --system-id=a2 --align 4 --fixed-size 1M

--- a/wic/sdimage-stratix10.wks
+++ b/wic/sdimage-stratix10.wks
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image for the Intel
 # Stratix 10 SoC. Boot files are located in the first vfat partition.
 
-part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 16
+part --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 16
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4


### PR DESCRIPTION
wic modifies /etc/fstab to add mount points
listed in the wks file.  We do not want the fat
partition mounted by default

Signed-off-by: Dalon Westergreen <dwesterg@gmail.com>