### PR TITLE
Another fix for the socfpga image class

### DIFF
--- a/classes/sdcard_image-socfpga.bbclass
+++ b/classes/sdcard_image-socfpga.bbclass
@@ -41,7 +41,8 @@ SDIMG_ROOTFS_TYPE = "ext3"
 SDIMG_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.${SDIMG_ROOTFS_TYPE}"
 
 
-do_image_socfpga-sdimg[depends] += " \
+do_image_socfpga_sdimg[depends] += " \
+                       coreutils-native:do_populate_sysroot \
                        parted-native:do_populate_sysroot \
                        mtools-native:do_populate_sysroot \
                        dosfstools-native:do_populate_sysroot \


### PR DESCRIPTION
Name had to change from  do_image_socfpga-sdimg[depends] to do_image_socfpga_sdimg[depends] . And we need sync (coreutils) as well.