### PR TITLE
Remove sdcard class INHERIT from arria5 machine conf

### DIFF
--- a/conf/machine/arria5.conf
+++ b/conf/machine/arria5.conf
@@ -17,5 +17,3 @@ KERNEL_DEVICETREE_arria5 ?= " \
 				socfpga_arria5_socdk.dtb \
 				"
 
-# Add support for SDCARD creation
-IMAGE_CLASSES += "sdcard_image-socfpga"


### PR DESCRIPTION
sdcard image class is no longer valid, remove the INHERIT
for the class

Signed-off-by: Dalon Westergreen <dwesterg@gmail.com>