### PR TITLE
Exchange A2 and ext4 rootfs partitions in wic image

### DIFF
--- a/conf/machine/include/socfpga.inc
+++ b/conf/machine/include/socfpga.inc
@@ -34,7 +34,7 @@ SPL_BINARY_arria5 = "u-boot-with-spl.sfp"
 
 # Set extlinux.conf up
 UBOOT_EXTLINUX ??= "0"
-UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk0p2"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk0p3"
 UBOOT_EXTLINUX_LABELS ?= "default"
 UBOOT_EXTLINUX_CONSOLE ?= "earlycon"
 UBOOT_EXTLINUX_MENU_DESCRIPTION_default ?= "Linux Default"

--- a/recipes-bsp/u-boot/files/v2016.11/cyclone5-socdk.env
+++ b/recipes-bsp/u-boot/files/v2016.11/cyclone5-socdk.env
@@ -7,5 +7,5 @@ fdt_addr=100
 loadaddr=0x01000000
 mmcboot=setenv bootargs console=ttyS0,115200 root=${mmcroot} rw rootwait;bootz ${loadaddr} - ${fdt_addr}
 mmcload=mmc rescan;load mmc 0:1 ${loadaddr} ${bootimage};load mmc 0:1 ${fdt_addr} ${fdtimage}
-mmcroot=/dev/mmcblk0p2
+mmcroot=/dev/mmcblk0p3
 ramboot=setenv bootargs console=ttyS0,115200;bootm ${loadaddr} - ${fdt_addr}

--- a/recipes-bsp/u-boot/files/v2016.11/de0-nano-soc.env
+++ b/recipes-bsp/u-boot/files/v2016.11/de0-nano-soc.env
@@ -7,5 +7,5 @@ fdt_addr=100
 loadaddr=0x01000000
 mmcboot=setenv bootargs console=ttyS0,115200 root=${mmcroot} rw rootwait;bootz ${loadaddr} - ${fdt_addr}
 mmcload=mmc rescan;load mmc 0:1 ${loadaddr} ${bootimage};load mmc 0:1 ${fdt_addr} ${fdtimage}
-mmcroot=/dev/mmcblk0p2
+mmcroot=/dev/mmcblk0p3
 ramboot=setenv bootargs console=ttyS0,115200;bootm ${loadaddr} - ${fdt_addr}

--- a/recipes-bsp/u-boot/files/v2017.07/cyclone5-socdk.env
+++ b/recipes-bsp/u-boot/files/v2017.07/cyclone5-socdk.env
@@ -7,5 +7,5 @@ fdt_addr=100
 loadaddr=0x01000000
 mmcboot=setenv bootargs console=ttyS0,115200 root=${mmcroot} rw rootwait;bootz ${loadaddr} - ${fdt_addr}
 mmcload=mmc rescan;load mmc 0:1 ${loadaddr} ${bootimage};load mmc 0:1 ${fdt_addr} ${fdtimage}
-mmcroot=/dev/mmcblk0p2
+mmcroot=/dev/mmcblk0p3
 ramboot=setenv bootargs console=ttyS0,115200;bootm ${loadaddr} - ${fdt_addr}

--- a/recipes-bsp/u-boot/files/v2017.07/de0-nano-soc.env
+++ b/recipes-bsp/u-boot/files/v2017.07/de0-nano-soc.env
@@ -7,5 +7,5 @@ fdt_addr=100
 loadaddr=0x01000000
 mmcboot=setenv bootargs console=ttyS0,115200 root=${mmcroot} rw rootwait;bootz ${loadaddr} - ${fdt_addr}
 mmcload=mmc rescan;load mmc 0:1 ${loadaddr} ${bootimage};load mmc 0:1 ${fdt_addr} ${fdtimage}
-mmcroot=/dev/mmcblk0p2
+mmcroot=/dev/mmcblk0p3
 ramboot=setenv bootargs console=ttyS0,115200;bootm ${loadaddr} - ${fdt_addr}

--- a/wic/sdimage-cyclone5-arria5.wks
+++ b/wic/sdimage-cyclone5-arria5.wks
@@ -4,5 +4,5 @@
 # the third partition.
 
 part --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 16
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4
 part --source rawcopy --sourceparams="file=u-boot-with-spl.sfp" --ondisk mmcblk --system-id=a2 --align 4 --fixed-size 1M
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4


### PR DESCRIPTION
This would allow to later on resize the rootfs
partition inside of the Linux if the storage media
used is originally bigger than the image itself. It
would effectively allow to utilize the entire storage
media from the Linux OS on the device.

Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>