### PR TITLE
mainline: update u-boot version to 2019.01 for cyclone5

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILE_COLLECTIONS += "meta-altera"
 BBFILE_PATTERN_meta-altera := "^${LAYERDIR}/"
 # increase the number
 BBFILE_PRIORITY_meta-altera = "6"
-LAYERSERIES_COMPAT_meta-altera = "sumo"
+LAYERSERIES_COMPAT_meta-altera = "thud"
 # yves
 BBDEBUG = "yes"
 

--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/socfpga.inc
 
-PREFERRED_VERSION_u-boot-socfpga ?= "v2018.05%"
+PREFERRED_VERSION_u-boot-socfpga ?= "v2019.01%"
 
 UBOOT_CONFIG ??= "cyclone5-socdk"
 

--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -15,6 +15,12 @@ UBOOT_CONFIG[sockit] = "socfpga_sockit_defconfig"
 UBOOT_CONFIG[socrates] = "socfpga_socrates_defconfig"
 UBOOT_CONFIG[sr1500] = "socfpga_sr1500_defconfig"
 
+# Some versions of u-boot use .bin and others use .img.
+# By default we use .sfp as this is what is generated
+# for Cyclone V by the U-Boot.
+UBOOT_SUFFIX = "sfp"
+UBOOT_BINARY = "u-boot-with-spl.${UBOOT_SUFFIX}"
+
 KMACHINE = "cyclone5"
 
 # Default kernel devicetrees

--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/socfpga.inc
 
-PREFERRED_VERSION_u-boot-socfpga ?= "v2017.09%"
+PREFERRED_VERSION_u-boot-socfpga ?= "v2018.05%"
 
 UBOOT_CONFIG ??= "cyclone5-socdk"
 

--- a/recipes-bsp/u-boot/u-boot-socfpga-common.inc
+++ b/recipes-bsp/u-boot/u-boot-socfpga-common.inc
@@ -1,9 +1,6 @@
 HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"
 SECTION = "bootloaders"
 
-LICENSE = "GPLv2+"
-LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
-
 PV_append = "+git${SRCPV}"
 
 SRC_URI = "git://git.denx.de/u-boot.git;branch=master"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.05.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.05.bb
@@ -1,6 +1,9 @@
 require u-boot-socfpga-common.inc
 require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+
 # This revision corresponds to the tag "v2016.05"
 # We use the revision in order to avoid having to fetch it from the
 # repo during parse 

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2016.11.bb
@@ -4,6 +4,9 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
 FILESEXTRAPATHS =. "${THISDIR}/files/v2016.11:"
 
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+
 # This revision corresponds to the tag "v2016.11"
 # We use the revision in order to avoid having to fetch it from the
 # repo during parse 

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2017.07.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2017.07.bb
@@ -4,6 +4,9 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
 FILESEXTRAPATHS =. "${THISDIR}/files/v2017.07:"
 
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+
 # This revision corresponds to the tag "v2017.07"
 # We use the revision in order to avoid having to fetch it from the
 # repo during parse 

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2017.09.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2017.09.bb
@@ -3,6 +3,9 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
 FILESEXTRAPATHS =. "${THISDIR}/files/v2017.09:"
 
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+
 SRCREV = "c98ac3487e413c71e5d36322ef3324b21c6f60f9"
 
 # Stratix10 is not mainlined yet

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2018.03.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2018.03.bb
@@ -3,6 +3,9 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
 FILESEXTRAPATHS =. "${THISDIR}/files/v2018.03:"
 
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+
 SRCREV = "f95ab1fb6e37f0601f397091bb011edf7a98b890"
 
 SRC_URI_append = "\

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2018.05.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2018.05.bb
@@ -1,0 +1,19 @@
+require u-boot-socfpga-common.inc
+require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+
+FILESEXTRAPATHS =. "${THISDIR}/files/v2018.05:"
+
+SRCREV = "890e79f2b1c26c5ba1a86d179706348aec7feef7"
+
+SRC_URI_append = "\
+    "
+
+# Some versions of u-boot use .bin and others use .img.
+# By default we use .sfp as this is what is generated
+# for Cyclone V by the U-Boot.
+UBOOT_SUFFIX = "sfp"
+UBOOT_BINARY = "u-boot-with-spl.${UBOOT_SUFFIX}"
+
+UBOOT_MAKE_TARGET ?= "all"
+
+DEPENDS += "dtc-native bc-native u-boot-mkimage-native"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2018.05.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2018.05.bb
@@ -8,12 +8,4 @@ SRCREV = "890e79f2b1c26c5ba1a86d179706348aec7feef7"
 SRC_URI_append = "\
     "
 
-# Some versions of u-boot use .bin and others use .img.
-# By default we use .sfp as this is what is generated
-# for Cyclone V by the U-Boot.
-UBOOT_SUFFIX = "sfp"
-UBOOT_BINARY = "u-boot-with-spl.${UBOOT_SUFFIX}"
-
-UBOOT_MAKE_TARGET ?= "all"
-
 DEPENDS += "dtc-native bc-native u-boot-mkimage-native"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2018.05.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2018.05.bb
@@ -3,6 +3,9 @@ require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
 FILESEXTRAPATHS =. "${THISDIR}/files/v2018.05:"
 
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+
 SRCREV = "890e79f2b1c26c5ba1a86d179706348aec7feef7"
 
 SRC_URI_append = "\

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2019.01.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2019.01.bb
@@ -1,0 +1,14 @@
+require u-boot-socfpga-common.inc
+require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
+
+FILESEXTRAPATHS =. "${THISDIR}/files/v2019.01:"
+
+SRCREV = "d3689267f92c5956e09cc7d1baa4700141662bff"
+
+SRC_URI_append = "\
+    "
+
+DEPENDS += "dtc-native bc-native bison-native u-boot-mkimage-native"


### PR DESCRIPTION
This pull request supersedes the pull request #108 submitted to thud branch. As stated in original pull request, following problematic is resolved:

> Current U-Boot version v2017.09 does not successfully compiles with the thud branch of Yocto due to conflict with libfdt headers are presented twice: once in sysroot and once in u-boot tree itself.
> 
> The version v2018.05 resolves this issue, and therefore should be used with thud branch further.
> 
> 

Mainline build has been verified using Terasic SoCkit, following version information received from the board:
`root@cyclone5:~# uname -a
Linux cyclone5 4.14.73-ltsi-altera #1 SMP Wed Jan 9 08:35:08 UTC 2019 armv7l armv7l armv7l GNU/Linux
root@cyclone5:~# cat /etc/issue
Poky (Yocto Project Reference Distro) 2.6+snapshot \n \l`