### PR TITLE
linux-altera: rename socfpga_cyclone5_de0_{sockit,nano_soc}

### DIFF
--- a/recipes-kernel/linux/linux-altera.inc
+++ b/recipes-kernel/linux/linux-altera.inc
@@ -23,7 +23,7 @@ KBRANCH ?= "${LINUX_VERSION_PREFIX}${LINUX_VERSION}${LINUX_VERSION_SUFFIX}"
 SRC_URI = "${KERNEL_REPO};protocol=${KERNEL_PROT};branch=${KBRANCH}"
 
 # Default kernel devicetrees
-KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5_socdk.dtb socfpga_cyclone5_sockit.dtb socfpga_cyclone5_socrates.dtb socfpga_cyclone5_de0_sockit.dtb"
+KERNEL_DEVICETREE_cyclone5 ?= "socfpga_cyclone5_socdk.dtb socfpga_cyclone5_sockit.dtb socfpga_cyclone5_socrates.dtb socfpga_cyclone5_de0_nano_soc.dtb"
 KERNEL_DEVICETREE_arria5 ?= "socfpga_arria5_socdk.dtb"
 KERNEL_DEVICETREE_arria10 ?= "socfpga_arria10_socdk_sdmmc.dtb socfpga_arria10_socdk_qspi.dtb socfpga_arria10_swvp.dtb"
 KERNEL_DEVICETREE_stratix10swvp ?= "altera/stratix10_swvp.dtb"


### PR DESCRIPTION
The commit
202eb5481421 ARM: dts: socfpga: Rename socfpga_cyclone5_de0_{sockit,nano_soc}
on the linux-altera repository renamed the socfpga_cyclone5_de0_sockit.dtb devicetree
to socfpga_cyclone5_de0_nano_soc.dtb.
Rename it also here