### PR TITLE
stratix10: update machine conf to add serial consoles

### DIFF
--- a/conf/machine/stratix10.conf
+++ b/conf/machine/stratix10.conf
@@ -20,9 +20,7 @@ KERNEL_IMAGETYPE = "Image"
 
 KERNEL_DEVICETREE ?= "altera/socfpga_stratix10_socdk.dtb"
 
-# we do not want to have getty running on tty1 as we run
-# auto-serial-console there
-#USE_VT = "0"
+SERIAL_CONSOLES = "115200;ttyS0"
 
 # Add variables for wic creation of sdcard image
 IMAGE_BOOT_FILES ?= " \


### PR DESCRIPTION
Remove reference to auto-serial-console as it is in
meta-linaro which is not needed.  Add SERIAL_CONSOLES
to enable a terminal on ttyS0.

Signed-off-by: Dalon Westergreen <dwesterg@gmail.com>