### PR TITLE
Only support Warrior in LAYERS_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILE_COLLECTIONS += "meta-altera"
 BBFILE_PATTERN_meta-altera := "^${LAYERDIR}/"
 # increase the number
 BBFILE_PRIORITY_meta-altera = "6"
-LAYERSERIES_COMPAT_meta-altera = "sumo thud warrior"
+LAYERSERIES_COMPAT_meta-altera = "warrior"
 # yves
 BBDEBUG = "yes"
 


### PR DESCRIPTION
Warrior specific changes are needed, and as a result
sumo and thud support must be disabled.

Signed-off-by: Dalon Westergreen <dwesterg@gmail.com>