### PR TITLE
Update cyclone5.conf

### DIFF
--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -22,7 +22,7 @@ KERNEL_DEVICETREE ?= "\
 			socfpga_cyclone5_socdk.dtb \
 			socfpga_cyclone5_sockit.dtb \
 			socfpga_cyclone5_socrates.dtb \
-			socfpga_cyclone5_de0_nano_soc.dtb \
+			socfpga_cyclone5_de0_sockit.dtb \
 			socfpga_cyclone5_mcvevk.dtb \
 			socfpga_cyclone5_sodia.dtb \
 			socfpga_cyclone5_trcom.dtb \


### PR DESCRIPTION
Changing the dtb file generated as wic configuration would fail if socfpga_cyclone5_de0_sockit.dtb is not available. Also the the script in 
layers/meta-altera/recipes-kernel/linux/linux-altera-ltsi-rt_4.14-73.bb:11:KERNEL_DEVICETREE_remove_cyclone5 = "socfpga_cyclone5_de0_nano_soc.dtb"