### PR TITLE
u-boot: update to 2019.07 release and add patch for a10 fix

### DIFF
--- a/recipes-bsp/u-boot/files/v2019.07/0001-fpga-arria10-Fix-error-in-fpga-pin-configuration.patch
+++ b/recipes-bsp/u-boot/files/v2019.07/0001-fpga-arria10-Fix-error-in-fpga-pin-configuration.patch
@@ -1,0 +1,38 @@
+From 58b4cc1a3d1e4a989b65892b97af119c25d9a511 Mon Sep 17 00:00:00 2001
+From: Dalon Westergreen <dalon.westergreen@intel.com>
+Date: Tue, 16 Jul 2019 09:12:53 -0700
+Subject: [PATCH] fpga: arria10: Fix error in fpga pin configuration
+
+Pin configuration of the FPGA devicetree block should be done
+after core configuration in the arria10 fpga driver.  This fix
+corrects the check of status, and ensures that the fpga pin mux
+is configured on correct configuration of the core fpga image.
+
+Signed-off-by: Dalon Westergreen <dalon.westergreen@intel.com>
+---
+ drivers/fpga/socfpga_arria10.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/fpga/socfpga_arria10.c b/drivers/fpga/socfpga_arria10.c
+index 285280e507..5fb9d6a191 100644
+--- a/drivers/fpga/socfpga_arria10.c
++++ b/drivers/fpga/socfpga_arria10.c
+@@ -936,10 +936,11 @@ int socfpga_load(Altera_desc *desc, const void *rbf_data, size_t rbf_size)
+ 	fpgamgr_program_write(rbf_data, rbf_size);
+ 
+ 	status = fpgamgr_program_finish();
+-	if (status) {
+-		config_pins(gd->fdt_blob, "fpga");
+-		puts("FPGA: Enter user mode.\n");
+-	}
++	if (status)
++		return status;
++
++	config_pins(gd->fdt_blob, "fpga");
++	puts("FPGA: Enter user mode.\n");
+ 
+ 	return status;
+ }
+-- 
+2.21.0
+

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2019.07.bb
@@ -8,7 +8,7 @@ PR = "2"
 
 FILESEXTRAPATHS =. "${THISDIR}/files/v2019.07:"
 
-SRCREV = "7e090b466c5ba874d31c1bf22c3a130d516cdc32"
+SRCREV = "e5aee22e4be75e75a854ab64503fc80598bc2004"
 
 SRC_URI_append = "\
 	file://0001-ARM-socfpga-stratix10-Enable-PSCI-system-reset.patch \
@@ -24,6 +24,7 @@ SRC_URI_append = "\
 	file://0011-ARM-socfpga-stratix10-Remove-CONFIG_OF_EMBED.patch \
 	file://0012-ARM-socfpga-stratix10-Temporarily-revert-to-2GB-DRAM.patch \
 	file://0001-ARM-socfpga-Stratix10-Disable-CONFIG_PSCI_RESET.patch \
+	file://0001-fpga-arria10-Fix-error-in-fpga-pin-configuration.patch \
     "
 
 DEPENDS += "dtc-native bc-native bison-native u-boot-mkimage-native"


### PR DESCRIPTION
Update u-boot to release tag and add fix for arria10 to
release fpga routed HPS peripherals properly.

Signed-off-by: Dalon Westergreen <dwesterg@gmail.com>