### PR TITLE
Update de0 nano dtb reference

### DIFF
--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -22,7 +22,7 @@ KERNEL_DEVICETREE ?= "\
 			socfpga_cyclone5_socdk.dtb \
 			socfpga_cyclone5_sockit.dtb \
 			socfpga_cyclone5_socrates.dtb \
-			socfpga_cyclone5_de0_sockit.dtb \
+			socfpga_cyclone5_de0_nano_soc.dtb \
 			socfpga_cyclone5_mcvevk.dtb \
 			socfpga_cyclone5_sodia.dtb \
 			socfpga_cyclone5_trcom.dtb \


### PR DESCRIPTION
Without updating the reference to the write dtb on the kernel (as proposed by this PR) I was not able to compile yocto with this meta-altera