### PR TITLE
Cyclone5: Remove socfpga_cyclone5_trcom.dtb from dts list

### DIFF
--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -25,7 +25,6 @@ KERNEL_DEVICETREE ?= "\
 			socfpga_cyclone5_de0_nano_soc.dtb \
 			socfpga_cyclone5_mcvevk.dtb \
 			socfpga_cyclone5_sodia.dtb \
-			socfpga_cyclone5_trcom.dtb \
 			socfpga_cyclone5_vining_fpga.dtb \
 			"
 


### PR DESCRIPTION
socfpga_cyclone5_trcom.dtb is no longer present in the
kernel source.

Signed-off-by: Dalon Westergreen <dwesterg@gmail.com>