### PR TITLE
machine: use MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS

### DIFF
--- a/conf/machine/agilex.conf
+++ b/conf/machine/agilex.conf
@@ -22,3 +22,4 @@ IMAGE_BOOT_FILES ?= " \
 WKS_FILE ?= "sdimage-stratix10-agilex.wks"
 IMAGE_FSTYPES += "wic"
 
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-modules"

--- a/conf/machine/stratix10.conf
+++ b/conf/machine/stratix10.conf
@@ -20,3 +20,4 @@ IMAGE_BOOT_FILES ?= " \
 WKS_FILE ?= "sdimage-stratix10-agilex.wks"
 IMAGE_FSTYPES += "wic"
 
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-modules"


### PR DESCRIPTION
Image configurations based on core-image-minimal required
MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS to install a list of
recommended machine-specific packages as part of the image
being built.

Signed-off-by: Chang Rebecca Swee Fun <rebecca.swee.fun.chang@intel.com>