### PR TITLE
Update on arria10 machine config

### DIFF
--- a/conf/machine/arria10.conf
+++ b/conf/machine/arria10.conf
@@ -22,9 +22,10 @@ KERNEL_DEVICETREE ?= "\
 			socfpga_arria10_socdk_nand.dtb \
 			"
 
-JFFS2_ERASEBLOCK ?= "${@bb.utils.contains("A10_IMAGE_TYPE", "NAND", "-e 0x20000", "", d)} \
-		     ${@bb.utils.contains("A10_IMAGE_TYPE", "QSPI", "-e 0x10000", "", d)}"
-EXTRA_IMAGECMD_jffs2 ?= "--squash -s 256 ${JFFS2_ERASEBLOCK}"
+EXTRA_IMAGECMD_jffs2 ?= "\
+	${@bb.utils.contains("A10_IMAGE_TYPE", "NAND", "-e 0x20000 -s 0x200", "", d)} \
+	${@bb.utils.contains("A10_IMAGE_TYPE", "QSPI", "-e 0x10000", "", d)} \
+	"
 
 SERIAL_CONSOLES ?= "115200;ttyS0"
 

--- a/conf/machine/arria10.conf
+++ b/conf/machine/arria10.conf
@@ -22,7 +22,7 @@ KERNEL_DEVICETREE ?= "\
 			socfpga_arria10_socdk_nand.dtb \
 			"
 
-EXTRA_IMAGECMD_jffs2 ?= "\
+EXTRA_IMAGECMD_jffs2 ?= "-n -q \
 	${@bb.utils.contains("A10_IMAGE_TYPE", "NAND", "-e 0x20000 -s 0x200", "", d)} \
 	${@bb.utils.contains("A10_IMAGE_TYPE", "QSPI", "-e 0x10000", "", d)} \
 	"


### PR DESCRIPTION
1. Changed page size for NAND flash to a supported page size
2. Added options for mkfs.jffs2 to remove cleanmarker and squash all user permission to root.

The changes in the machine conf have been tested on arria10 NAND flash and proven working.