### PR TITLE
Add missing SPL_BINARY name used in WKS file

### DIFF
--- a/conf/machine/cyclone5.conf
+++ b/conf/machine/cyclone5.conf
@@ -4,6 +4,8 @@
 
 require conf/machine/include/socfpga.inc
 
+SPL_BINARY = "u-boot-with-spl.sfp"
+
 UBOOT_CONFIG ??= "cyclone5-socdk"
 
 UBOOT_CONFIG[cyclone5-socdk] = "socfpga_cyclone5_defconfig"


### PR DESCRIPTION
The SPL binary must be part of the bootloader build artifacts in the deploy
dir since it is referenced in the Cyclone 5 WKS file.

Signed-off-by: Christian Thaler <christian.thaler@tes-dst.com>