### PR TITLE
U-boot Recipe Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Only branches listed appropriately in https://wiki.yoctoproject.org/wiki/Stable_
 Choosing Kernel Versions
 ==========================
 This layer has a few providers for the kernel.  These are the linux-altera, 
-linux-altera-ltsi, and linux-altera-ltsi-rt kernels.  There are also 
+linux-altera-lts, linux-altera-ltsi, and linux-altera-ltsi-rt kernels.  There are also
 linux-altera-dev and linux-altera-ltsi-dev kernels which follow the current 
 development versions of those kernels.
 
@@ -28,6 +28,11 @@ To specify a linux-altera kernel, add the following to your conf/local.conf
 
 	PREFERRED_PROVIDER_virtual/kernel = "linux-altera"
 	PREFERRED_VERSION_linux-altera = "4.3%"
+
+or for the linux-altera-lts kernel
+
+	PREFERRED_PROVIDER_virtual/kernel = "linux-altera-lts"
+	PREFERRED_VERSION_linux-altera = "5.4%"
 
 or for the linux-altera-ltsi kernel	
 
@@ -65,6 +70,7 @@ the use of this toolchain in Yocto add the following to conf/local.conf
 To use older kernels not supported by GCC 5+ you will need to use the 4.9 toolchain.
 
 For Yocto:
+
 	GCCVERSION = "linaro-4.9"
 	SDKGCCVERSION = "linaro-4.9"
 	DEFAULTTUNE = "cortexa9hf-neon"

--- a/recipes-bsp/u-boot/u-boot-socfpga-common.inc
+++ b/recipes-bsp/u-boot/u-boot-socfpga-common.inc
@@ -1,16 +1,29 @@
 HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"
 SECTION = "bootloaders"
-DEPENDS += "flex-native bison-native"
+DEPENDS += "flex-native bison-native dtc-native bc-native u-boot-mkimage-native"
 
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 PE = "1"
 
+require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+
+UBOOT_REPO ?= "git://github.com/altera-opensource/u-boot-socfpga.git"
+UBOOT_PROT ?= "https"
+
+UBOOT_VERSION_PREFIX ?= "socfpga_"
+UBOOT_VERSION ?= "v2019.10"
+UBOOT_BRANCH ?= "${UBOOT_VERSION_PREFIX}${UBOOT_VERSION}"
+
+SRCREV ?= "${AUTOREV}"
 PV_append = "+git${SRCPV}"
 
 S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
 
 RPROVIDES_${PN} += "u-boot"
+
+SRC_URI = "${UBOOT_REPO};protocol=${UBOOT_PROT};branch=${UBOOT_BRANCH}"
 
 UBOOT_CONFIG[agilex-socdk] = "socfpga_agilex_defconfig"
 UBOOT_CONFIG[agilex-socdk-qspi] = "socfpga_agilex_qspi_defconfig"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2019.04.bb
@@ -1,7 +1,5 @@
 require u-boot-socfpga-common.inc
-require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
-SRC_URI = "git://github.com/altera-opensource/u-boot-socfpga.git;branch=socfpga_v2019.04"
+UBOOT_VERSION = "v2019.04"
+
 SRCREV = "6296fdb7da9e205bc34416f38631715fb6d74e71"
-
-DEPENDS += "dtc-native bc-native u-boot-mkimage-native"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2019.10.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2019.10.bb
@@ -1,7 +1,5 @@
 require u-boot-socfpga-common.inc
-require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
-SRC_URI = "git://github.com/altera-opensource/u-boot-socfpga.git;branch=socfpga_v2019.10"
+UBOOT_VERSION = "v2019.10"
+
 SRCREV = "34638cc921269665e43340a50552302bd358f793"
-
-DEPENDS += "dtc-native bc-native u-boot-mkimage-native"

--- a/recipes-bsp/u-boot/u-boot-socfpga_v2020.04.bb
+++ b/recipes-bsp/u-boot/u-boot-socfpga_v2020.04.bb
@@ -1,7 +1,5 @@
 require u-boot-socfpga-common.inc
-require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
-SRC_URI = "git://github.com/altera-opensource/u-boot-socfpga.git;branch=socfpga_v2020.04"
+UBOOT_VERSION = "v2020.04"
+
 SRCREV = "2cbc36afbb31bee6e245291c51c283dbde0e3b89"
-
-DEPENDS += "dtc-native bc-native u-boot-mkimage-native"


### PR DESCRIPTION
This is similar approach to the kernel recipe where we have one common include file for common variables.
This approach can help us to build u-boot from different repo by setting UBOOT_REPO in conf/local.conf.