### PR TITLE
wic: resolve boot issue when using wic images

### DIFF
--- a/wic/sdimage-arria10.wks
+++ b/wic/sdimage-arria10.wks
@@ -3,6 +3,6 @@
 # Boot files are located in the first vfat partition and u-Boot is located in
 # the third partition.
 
-part --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 50M
-part --source rawcopy --sourceparams="file=u-boot-with-spl.sfp" --ondisk mmcblk --system-id=a2 --align 4 --fixed-size 10M
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4
+part --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 1024 --size 50M
+part --source rawcopy --sourceparams="file=u-boot-with-spl.sfp" --ondisk mmcblk --system-id=a2 --align 1024 --fixed-size 10M
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 1024

--- a/wic/sdimage-cyclone5-arria5.wks
+++ b/wic/sdimage-cyclone5-arria5.wks
@@ -3,6 +3,6 @@
 # Boot files are located in the first vfat partition and u-Boot is located in
 # the third partition.
 
-part --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 16
-part --source rawcopy --sourceparams="file=u-boot-with-spl.sfp" --ondisk mmcblk --system-id=a2 --align 4 --fixed-size 1M
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4
+part --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 1024 --size 16
+part --source rawcopy --sourceparams="file=u-boot-with-spl.sfp" --ondisk mmcblk --system-id=a2 --align 1024 --fixed-size 1M
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 1024


### PR DESCRIPTION
New u-boot version has its binary aligned to start from 2048 boot sector.

Signed-off-by: Chang Rebecca Swee Fun <rebecca.swee.fun.chang@intel.com>