### PR TITLE
atf: update recipe SRC_URI structure

### DIFF
--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware.inc
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware.inc
@@ -11,9 +11,11 @@ inherit deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PROT ?= "https"
-BRANCH ?= "socfpga_v2.3"
-SRC_URI ?= "git://github.com/altera-opensource/arm-trusted-firmware.git;protocol=${PROT};branch=${BRANCH}"
+ATF_PROT ?= "https"
+ATF_BRANCH ?= "socfpga_v2.3"
+ATF_REPO ?= "git://github.com/altera-opensource/arm-trusted-firmware.git"
+
+SRC_URI = "${ATF_REPO};protocol=${ATF_PROT};branch=${ATF_BRANCH}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Make SRC_URI composed from ATF_REPO, ATF_BRANCH and ATF_PROT
as we have use case to change the ATF_REPO location and branch.

Signed-off-by: Chang Rebecca Swee Fun <rebecca.swee.fun.chang@intel.com>